### PR TITLE
Add support for almond.js style AMD loading

### DIFF
--- a/WebConsole.js
+++ b/WebConsole.js
@@ -1,7 +1,7 @@
 ;
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define([''], factory)
+    define('mocha/web-console-reporter', [], factory)
   } else {
     root.WebConsole = factory()
   }


### PR DESCRIPTION
Almond (https://github.com/jrburke/almond) loads only modules with an explicit name. Related: https://github.com/jrburke/almond/pull/49

Dunno if this breaks require.js or something else, haven't tried :-)

From [readme](https://github.com/jrburke/almond/blob/master/README.md):

> It usually means that there is a define()'d module, but it is missing a name, something that looks like this:

```
define(function () {});
```

> when it should look like:

```
define('someName', function () {});
```
