### PR TITLE
Remove root suite from log

### DIFF
--- a/WebConsole.js
+++ b/WebConsole.js
@@ -64,10 +64,12 @@
       var parameter = '?grep=' + encodeURIComponent(suite.fullTitle()) + '&' + reporterQueryParameter
       var location = document.location
       var url = location.origin + location.pathname + parameter
-      calls.push(['group', suite, suite.title])
-      calls.push(['groupCollapsed', suite , 'url'])
-      calls.push(['log', suite, url])
-      calls.push(['groupEnd', suite])
+      if (!suite.root) {
+        calls.push(['group', suite, suite.title])
+        calls.push(['groupCollapsed', suite , 'url'])
+        calls.push(['log', suite, url])
+        calls.push(['groupEnd', suite])
+      }
     })
 
     runner.on('suite end', function(suite) {


### PR DESCRIPTION
The root suit is unnamed and will only crate an extra empty line and (the worst) an extra indentation level to the output.